### PR TITLE
fix(): File upload

### DIFF
--- a/e2e/api-spec.json
+++ b/e2e/api-spec.json
@@ -499,6 +499,44 @@
           }
         ]
       }
+    },
+    "/api/cats/upload": {
+      "post": {
+        "operationId": "CatsController_uploadFile",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "cats"
+        ],
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "basic": []
+          }
+        ]
+      }
     }
   }
 }

--- a/e2e/src/cats/cats.controller.ts
+++ b/e2e/src/cats/cats.controller.ts
@@ -1,5 +1,15 @@
-import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
 import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Query,
+  UseInterceptors,
+  UploadedFile
+} from '@nestjs/common';
+import {
+  ApiBody,
   ApiBearerAuth,
   ApiConsumes,
   ApiOperation,
@@ -11,6 +21,7 @@ import { CatsService } from './cats.service';
 import { Cat } from './classes/cat.class';
 import { CreateCatDto } from './dto/create-cat.dto';
 import { PaginationQuery } from './dto/pagination-query.dto';
+import { FileInterceptor } from '@nestjs/platform-express';
 
 @ApiSecurity('basic')
 @ApiBearerAuth()
@@ -68,4 +79,24 @@ export class CatsController {
 
   @Get('site*')
   getSite() {}
+
+  @Post('upload')
+  @ApiConsumes('multipart/form-data')
+  @UseInterceptors(FileInterceptor('file'))
+  @ApiBody({
+    type: 'multipart/form-data',
+    required: true,
+    schema: {
+      type: 'object',
+      properties: {
+        file: {
+          type: 'string',
+          format: 'binary'
+        }
+      }
+    }
+  })
+  uploadFile(@UploadedFile() file) {
+    return file;
+  }
 }

--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -50,10 +50,16 @@ export class SchemaObjectFactory {
 
       const modelName = this.exploreModelSchema(param.type, schemas);
       const name = param.name || modelName;
-      const schema = {
-        ...((param as BaseParameterObject).schema || {}),
-        $ref: getSchemaPath(modelName)
-      };
+
+      const schema = modelName
+        ? {
+            ...((param as BaseParameterObject).schema || {}),
+            $ref: getSchemaPath(modelName)
+          }
+        : {
+            ...((param as BaseParameterObject).schema || {})
+          };
+
       const isArray = param.isArray;
       param = omit(param, 'isArray');
 


### PR DESCRIPTION
@see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#mediaTypeObject
According to spec multipart should be described in responseBody branch.
It is possible with use of @ApiBody annotation.
Code generator has been unnecesarily adding $ref to locally typed schema.

resolves: https://github.com/nestjs/swagger/issues/167

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information